### PR TITLE
composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "oxidcookbook/ocb_cleartmp",
+    "description": "Clear the tmp directory from the backend.",
+    "type": "oxid-module",
+    "require": {
+        "composer/installers": "~1.0"
+    }
+}


### PR DESCRIPTION
With this change, you can install ocb_cleartmp using composer by adding the following lines to your composer.json:

```
{
  "repositories": [
    { "type": "vcs", "url":  "https://github.com/OXIDCookbook/ocb_cleartmp.git" }
  ],

  "require": {
    "oxidcookbook/ocb_cleartmp": "dev-master"
  },

  "extra": {
    "installer-paths": {
      "shop/modules/ocb_cleartmp": ["oxidcookbook/ocb_cleartmp"]
    }
  }
}
```
