### PR TITLE
Update ocb_cleartmp_oxshopcontrol.php

### DIFF
--- a/core/ocb_cleartmp_oxshopcontrol.php
+++ b/core/ocb_cleartmp_oxshopcontrol.php
@@ -16,9 +16,7 @@ class ocb_cleartmp_oxshopcontrol extends ocb_cleartmp_oxshopcontrol_parent
         
         if ($blDevMode && !$oConf->isProductiveMode()) {
             $sTmpDir = realpath($oConf->getShopConfVar('sCompileDir'));
-            $aFiles = glob($sTmpDir.'/*{.php,.txt}', GLOB_BRACE);
-            $aFiles = array_merge($aFiles, glob($sTmpDir.'/smarty/*.php'));
-            $aFiles = array_merge($aFiles, glob($sTmpDir.'/ocb_cache/*.json'));
+            $aFiles = glob($sTmpDir.'{/smarty/,/ocb_cache/,/}*{.php,.txt,.json}', GLOB_BRACE);
             if (count($aFiles) > 0) {
                 foreach ($aFiles as $file) {
                     @unlink($file);


### PR DESCRIPTION
array_merge causes annoying PHP Warning:  array_merge(): Argument #2 is not an array... This update uses the power of glob().