### PR TITLE
show exceptions and errors in development mode

### DIFF
--- a/core/ocb_cleartmp_oxshopcontrol.php
+++ b/core/ocb_cleartmp_oxshopcontrol.php
@@ -25,4 +25,14 @@ class ocb_cleartmp_oxshopcontrol extends ocb_cleartmp_oxshopcontrol_parent
         }
         parent::_runOnce();
     }
+
+    /**
+     * Checks if shop is in development mode
+     *
+     * @return bool
+     */
+    protected function _isDebugMode()
+    {
+        return oxRegistry::getConfig()->getShopConfVar('blDevMode', null, 'module:ocb_cleartmp');
+    }
 }

--- a/core/ocb_cleartmp_oxshopcontrol.php
+++ b/core/ocb_cleartmp_oxshopcontrol.php
@@ -27,11 +27,39 @@ class ocb_cleartmp_oxshopcontrol extends ocb_cleartmp_oxshopcontrol_parent
     }
 
     /**
+     * Shows exceptionError page.
+     * possible reason: class does not exist etc. --> just redirect to start page.
+     *
+     * @param $oEx
+     */
+    protected function _handleSystemException($oEx)
+    {
+        //possible reason: class does not exist etc. --> just redirect to start page
+        if ($this->_isDevelopmentMode()) {
+            oxRegistry::get("oxUtilsView")->addErrorToDisplay($oEx);
+            $this->_process('exceptionError', 'displayExceptionError');
+        }
+        $oEx->debugOut();
+    }
+
+    /**
+     * Redirect to start page, in debug mode shows error message.
+     *
+     * @param $oEx
+     */
+    protected function _handleCookieException($oEx)
+    {
+        if ($this->_isDevelopmentMode()) {
+            oxRegistry::get("oxUtilsView")->addErrorToDisplay($oEx);
+        }
+    }
+
+    /**
      * Checks if shop is in development mode
      *
      * @return bool
      */
-    protected function _isDebugMode()
+    protected function _isDevelopmentMode()
     {
         return oxRegistry::getConfig()->getShopConfVar('blDevMode', null, 'module:ocb_cleartmp');
     }


### PR DESCRIPTION
Oxid redirects to offline or to startpage if an error occurred without the iDebug mode.
If you have the Debug mode enabled you get some annoying message in frontend.

With this pull-request you can see all errors and exceptions without annoying debug messages.
